### PR TITLE
Bugfix multiple same emails can be added to a list when saving at the same time

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -4,6 +4,7 @@ class List < ActiveRecord::Base
   has_many :santas, dependent: :destroy, inverse_of: :list
 
   accepts_nested_attributes_for :santas, reject_if: :all_blank, allow_destroy: true
+  validates_associated :santas
 
   validates :name, presence: true, length: { minimum: 2, maximum: 50 }
   validates :gift_day, presence: true

--- a/spec/models/list/shuffle_and_assign_santas_spec.rb
+++ b/spec/models/list/shuffle_and_assign_santas_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe List::ShuffleAndAssignSantas do
   describe '#assign_and_email' do
-    subject { List::ShuffleAndAssignSantas.new(list).assign_and_email }
+    subject { List::ShuffleAndAssignSantas.new(test_list.reload).assign_and_email }
 
-    let!(:list)   { FactoryGirl.create(:list) }
-    let!(:santas) { FactoryGirl.create_list(:santa, 5, list_id: list.id) }
+    let!(:test_list)   { FactoryGirl.create(:list) }
+    let!(:santas) { FactoryGirl.create_list(:santa, 5, list: test_list) }
 
     scenario 'all santas are assigned a recipient and no santa is unassigned' do
       subject
@@ -26,9 +26,9 @@ RSpec.describe List::ShuffleAndAssignSantas do
     end
 
     scenario 'the list should be locked after the method runs' do
-      expect(list.is_locked).to be_falsey
+      expect(test_list.is_locked).to be_falsey
       subject
-      expect(list.is_locked).to be_truthy
+      expect(test_list.is_locked).to be_truthy
     end
   end
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe List do
 
     it { should have_many(:santas).inverse_of(:list) }
     it "deletes associated santas if the list is deleted" do
-      expect { list.destroy }.to change { Santa.count }.by(-1)
+      expect { list.reload.destroy }.to change { Santa.count }.by(-1)
     end
   end
 


### PR DESCRIPTION
If a user tries to save two emails at the same time the validation check only looks at the database, not at what is in memory.

Have resolved it, and fixed breaking tests.